### PR TITLE
fix: server handler paths

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@ node_modules
 playground
 data
 .nuxt
+tests
 
 # files
 .releaserc

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Data provided by: https://github.com/dr5hn/countries-states-cities-database
 
 # Nuxt Module
 
-[![npm (scoped)](https://img.shields.io/npm/v/%40vis97c/nuxt-countries)](https://github.com/vis97c/countries-api/tree/master) [![CircleCI](https://dl.circleci.com/status-badge/img/gh/vis97c/countries-api/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/vis97c/countries-api/tree/master)
+[![npm (scoped)](https://img.shields.io/npm/v/nuxt-countries-api)](https://github.com/vis97c/countries-api/tree/master) [![CircleCI](https://dl.circleci.com/status-badge/img/gh/vis97c/countries-api/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/vis97c/countries-api/tree/master)
 
 ```shell
 npm i nuxt-countries-api

--- a/playground/server/middleware/access.ts
+++ b/playground/server/middleware/access.ts
@@ -116,8 +116,6 @@ export default defineEventHandler((event) => {
 		event.node.req.connection.remoteAddress ||
 		event.node.req.socket.remoteAddress;
 
-	console.log(ip);
-
 	if (ip && !logger.check(ip)) {
 		// cancel the request here
 		setResponseStatus(event, 429);

--- a/src/module.ts
+++ b/src/module.ts
@@ -31,22 +31,22 @@ export default defineNuxtModule<CountriesModuleOptions>({
 		// all countries
 		addServerHandler({
 			route: base,
-			handler: resolve(apiPath, "countries/index.ts"),
+			handler: resolve(apiPath, "countries/index"),
 		});
 		// single country
 		addServerHandler({
 			route: path.join(base, ":country"),
-			handler: resolve(apiPath, "countries/[country]/index.ts"),
+			handler: resolve(apiPath, "countries/[country]/index"),
 		});
 		// single state
 		addServerHandler({
 			route: path.join(base, ":country", ":state"),
-			handler: resolve(apiPath, "countries/[country]/[state]/index.ts"),
+			handler: resolve(apiPath, "countries/[country]/[state]/index"),
 		});
 		// single city
 		addServerHandler({
 			route: path.join(base, ":country", ":state", ":city"),
-			handler: resolve(apiPath, "countries/[country]/[state]/[city].ts"),
+			handler: resolve(apiPath, "countries/[country]/[state]/[city]"),
 		});
 	},
 });


### PR DESCRIPTION
Nuxt module docs do not address the fact that the file extensions are unnecesary